### PR TITLE
Fix CME in griefprevention addon

### DIFF
--- a/addons/griefprevention/src/main/java/xyz/jpenilla/squaremap/addon/griefprevention/task/SquaremapTask.java
+++ b/addons/griefprevention/src/main/java/xyz/jpenilla/squaremap/addon/griefprevention/task/SquaremapTask.java
@@ -47,7 +47,8 @@ public final class SquaremapTask extends BukkitRunnable {
         this.provider.clearMarkers(); // TODO track markers instead of clearing them
         Collection<Claim> topLevelClaims = GPHook.getClaims();
         if (topLevelClaims != null) {
-            topLevelClaims.stream()
+            List<Claim> snapshot = new ArrayList<>(topLevelClaims);
+            snapshot.stream()
                 .filter(claim -> claim.getGreaterBoundaryCorner().getWorld().getUID().equals(this.bukkitWorld.getUID()))
                 .filter(claim -> claim.parent == null)
                 .forEach(this::handleClaim);


### PR DESCRIPTION
## Summary
- prevent ConcurrentModificationException when reading claim data

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_688cd26ff35c832cb2467803f9c1b729